### PR TITLE
Tl/nethttpclientlogger request coverage

### DIFF
--- a/src/logger/HttpMessage.go
+++ b/src/logger/HttpMessage.go
@@ -12,7 +12,7 @@ import (
 /*
 * Submits request and response through logger.
  */
-func sendNetHttpClientMessage(logger *HttpLogger, resp *http.Response, start int64) {
+func sendNetHttpClientMessage(logger *HttpLogger, resp *http.Response, start int64) /* maybe return error */ {
 	request := resp.Request
 
 	if !logger.isEnabled() {

--- a/src/logger/HttpMessage.go
+++ b/src/logger/HttpMessage.go
@@ -20,7 +20,7 @@ func sendNetHttpClientMessage(logger *HttpLogger, resp *http.Response, start int
 	}
 
 	// copy details from request & response
-	message := buildNetHttpClientMessage(resp)
+	message := buildNetHttpClientMessage(request, resp)
 
 	copySessionField := logger.rules.CopySessionField()
 
@@ -63,9 +63,7 @@ func sendNetHttpClientMessage(logger *HttpLogger, resp *http.Response, start int
 /*
 * Builds list of key/value pairs for HTTP request and response.
  */
-func buildNetHttpClientMessage(resp *http.Response) [][]string {
-	request := resp.Request
-
+func buildNetHttpClientMessage(req *http.Request, resp *http.Response) [][]string {
 	var message [][]string
 
 	method := resp.Request.Method
@@ -73,14 +71,14 @@ func buildNetHttpClientMessage(resp *http.Response) [][]string {
 		message = append(message, []string{"request_method", method})
 	}
 
-	message = append(message, []string{"request_url", request.URL.RequestURI()})
+	message = append(message, []string{"request_url", req.URL.RequestURI()})
 	message = append(message, []string{"response_code", fmt.Sprint(resp.StatusCode)})
 
-	appendRequestHeaders(&message, request)
-	appendRequestParams(&message, request)
+	appendRequestHeaders(&message, req)
+	appendRequestParams(&message, req)
 	appendResponseHeaders(&message, resp)
 
-	reqBodyBytes, err := ioutil.ReadAll(request.Body)
+	reqBodyBytes, err := ioutil.ReadAll(req.Body)
 	reqBody := string(reqBodyBytes)
 	if err != nil && reqBody != "" {
 		message = append(message, []string{"request_body", reqBody})

--- a/src/logger/HttpMessage.go
+++ b/src/logger/HttpMessage.go
@@ -42,18 +42,11 @@ func sendNetHttpClientMessage(logger *HttpLogger, resp *http.Response, start int
 		}
 	}
 
-	// add timing details
-	// if now == 0 {
-	// 	now = time.Now().UnixNano() / int64(time.Millisecond)
-	// }
-
-	// if interval != 0 {
-	// 	message = append(message, []string{"interval", fmt.Sprint(interval)})
-	// }
-
+	// append time of logging
 	now := time.Now().UnixNano() / int64(time.Millisecond)
 	message = append(message, []string{"now", string(now)})
 
+	// append interval noting the time it took to log
 	interval := now - start
 	message = append(message, []string{"interval", fmt.Sprint(interval)})
 

--- a/src/logger/HttpMessage.go
+++ b/src/logger/HttpMessage.go
@@ -12,7 +12,7 @@ import (
 /*
 * Submits request and response through logger.
  */
-func sendNetHttpClientMessage(logger *HttpLogger, resp *http.Response, now int64, interval float64) {
+func sendNetHttpClientMessage(logger *HttpLogger, resp *http.Response, start int64) {
 	request := resp.Request
 
 	if !logger.isEnabled() {
@@ -43,21 +43,21 @@ func sendNetHttpClientMessage(logger *HttpLogger, resp *http.Response, now int64
 	}
 
 	// add timing details
-	if now == 0 {
-		timeNow := time.Now()
-		unixNano := timeNow.UnixNano()
-		umillisec := unixNano / int64(time.Millisecond)
+	// if now == 0 {
+	// 	now = time.Now().UnixNano() / int64(time.Millisecond)
+	// }
 
-		now = umillisec
-	}
+	// if interval != 0 {
+	// 	message = append(message, []string{"interval", fmt.Sprint(interval)})
+	// }
+
+	now := time.Now().UnixNano() / int64(time.Millisecond)
 	message = append(message, []string{"now", string(now)})
 
-	if interval != 0 {
-		message = append(message, []string{"interval", fmt.Sprint(interval)})
-	}
+	interval := now - start
+	message = append(message, []string{"interval", fmt.Sprint(interval)})
 
 	logger.submitIfPassing(message)
-
 }
 
 /*
@@ -89,7 +89,7 @@ func buildNetHttpClientMessage(resp *http.Response) [][]string {
 	respBodyBytes, err := ioutil.ReadAll(resp.Body)
 	var respBody string
 	if err != nil {
-		respBody := string(respBodyBytes)
+		respBody = string(respBodyBytes)
 	}
 
 	if respBody != "" {

--- a/src/logger/NetHttpClientLogger.go
+++ b/src/logger/NetHttpClientLogger.go
@@ -13,9 +13,16 @@ type NetHttpClientLogger struct {
 }
 
 // construct new logger with given options struct{rules string, schema string}
-func NewNetHttpClientLogger(options interface{}) *NetHttpClientLogger {
+func NewNetHttpClientLoggerOptions(options interface{}) *NetHttpClientLogger {
 	return &NetHttpClientLogger{
 		httpLogger: NewHttpLogger(options),
+	}
+}
+
+// construct new logger without options
+func NewNetHttpClientLogger() *NetHttpClientLogger {
+	return &NetHttpClientLogger{
+		httpLogger: NewHttpLogger(),
 	}
 }
 

--- a/src/logger/NetHttpClientLogger.go
+++ b/src/logger/NetHttpClientLogger.go
@@ -33,6 +33,8 @@ func (clientLogger *NetHttpClientLogger) Get(url string) (resp *http.Response, e
 		return resp, err
 	}
 
+	// before sending should we first check "if (status < 300 || status === 302)"?
+
 	// now = time.Now().UnixNano() / int64(time.Millisecond)
 	sendNetHttpClientMessage(logger, resp, start)
 

--- a/src/logger/NetHttpClientLogger.go
+++ b/src/logger/NetHttpClientLogger.go
@@ -34,6 +34,25 @@ func (clientLogger *NetHttpClientLogger) Get(url string) (resp *http.Response, e
 		return resp, err
 	}
 
+	// now = time.Now().UnixNano() / int64(time.Millisecond)
+	sendNetHttpClientMessage(logger, resp, start)
+
+	return resp, err
+}
+
+func (clientLogger *NetHttpClientLogger) Post(url string, contentType string, body io.Reader) (resp *http.Response, err error) {
+	// start time for logging interval
+	start := time.Now().UnixNano() / int64(time.Millisecond)
+
+	logger := clientLogger.httpLogger
+
+	// capture the response or error
+	resp, err = clientLogger.Client.Post(url, contentType, body)
+
+	if err != nil {
+		return resp, err
+	}
+
 	// before sending should we first check "if (status < 300 || status === 302)"?
 
 	// now = time.Now().UnixNano() / int64(time.Millisecond)
@@ -42,7 +61,7 @@ func (clientLogger *NetHttpClientLogger) Get(url string) (resp *http.Response, e
 	return resp, err
 }
 
-func (clientLogger *NetHttpClientLogger) Post(url string, contentType string, body io.Reader) (resp *http.Response, err error) {
+func (clientLogger *NetHttpClientLogger) Do() (resp *http.Response, err error) {
 	// start time for logging interval
 	start := time.Now().UnixNano() / int64(time.Millisecond)
 

--- a/src/logger/NetHttpClientLogger.go
+++ b/src/logger/NetHttpClientLogger.go
@@ -1,59 +1,40 @@
 package logger
 
 import (
-	"io/ioutil"
-	"log"
 	"net/http"
-	"net/http/httputil"
-	"os"
+	"time"
 )
 
 type NetHttpClientLogger struct {
 	http.Client
-	LOGFLAG   bool
-	isEnabled bool
+	httpLogger *HttpLogger
 }
 
-func (bcl *NetHttpClientLogger) Get(url string) (resp *http.Response, err error) {
+func NewNetHttpClientLogger(options interface{}) *NetHttpClientLogger {
+	return &NetHttpClientLogger{
+		httpLogger: NewHttpLogger(options),
+	}
+}
+
+func (logger *NetHttpClientLogger) Logger() *HttpLogger {
+	return logger.httpLogger
+}
+
+func (clientLogger *NetHttpClientLogger) Get(url string) (resp *http.Response, err error) {
+	// start time for logging interval
+	start := time.Now().UnixNano() / int64(time.Millisecond)
+
+	logger := clientLogger.httpLogger
+
 	// capture the response or error
-	getResp, getErr := bcl.Client.Get(url)
+	resp, err = clientLogger.Client.Get(url)
 
-	ioWriter := os.Stdout
-
-	// create or open a file to log to
-	if bcl.LOGFLAG {
-		ioWriter, err = os.OpenFile("./get.log",
-			os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	}
-
-	// create a log.Logger to direct output of logging
-	logger := log.New(ioWriter, "", log.LstdFlags)
-
-	// logging conditions
 	if err != nil {
-		logger.Println("FAILURE: GET Request")
-		req, _ := httputil.DumpRequest(getResp.Request, true)
-		logger.Println("URL: " + string(req))
-		logger.Println("ERROR: " + err.Error())
-		logger.Println("STATUS: " + getResp.Status)
-		//logger.Println("STATUS CODE: " + getResp.StatusCode)
-	} else {
-		bodyBytes, _ := ioutil.ReadAll(getResp.Body)
-		logger.Println("SUCCESS: GET Request")
-		logger.Println("URL: " + url)
-		logger.Println("RESPONSE: " + string(bodyBytes))
+		return resp, err
 	}
 
-	return getResp, getErr
-}
+	// now = time.Now().UnixNano() / int64(time.Millisecond)
+	sendNetHttpClientMessage(logger, resp, start)
 
-func newLogger() NetHttpClientLogger {
-	return NetHttpClientLogger{
-		LOGFLAG:   true,
-		isEnabled: true,
-	}
-}
-
-func (bcl *NetHttpClientLogger) SetLogFlag(flag bool) {
-	bcl.LOGFLAG = flag
+	return resp, err
 }

--- a/src/logger/NetHttpClientLogger.go
+++ b/src/logger/NetHttpClientLogger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"io"
 	"net/http"
 	"time"
 )
@@ -28,6 +29,27 @@ func (clientLogger *NetHttpClientLogger) Get(url string) (resp *http.Response, e
 
 	// capture the response or error
 	resp, err = clientLogger.Client.Get(url)
+
+	if err != nil {
+		return resp, err
+	}
+
+	// before sending should we first check "if (status < 300 || status === 302)"?
+
+	// now = time.Now().UnixNano() / int64(time.Millisecond)
+	sendNetHttpClientMessage(logger, resp, start)
+
+	return resp, err
+}
+
+func (clientLogger *NetHttpClientLogger) Post(url string, contentType string, body io.Reader) (resp *http.Response, err error) {
+	// start time for logging interval
+	start := time.Now().UnixNano() / int64(time.Millisecond)
+
+	logger := clientLogger.httpLogger
+
+	// capture the response or error
+	resp, err = clientLogger.Client.Post(url, contentType, body)
 
 	if err != nil {
 		return resp, err


### PR DESCRIPTION
According to initial planning, we are wrapping the `net.http.Client` struct which has every standard HTTP request method attached to it that a Go client application would need/use.

This PR adds the methods which wrap all the `net.http.Client` methods available to its pointer instance. This will allow any client application developer/maintainers to implement client-side API logging by simply replacing any instance of `net.http.Client` with our package's NetHttpClientLogger`.