### PR TITLE
updated message formatting before BaseLogger submit by adding json.Ma…

### DIFF
--- a/src/logger/BaseLogger.go
+++ b/src/logger/BaseLogger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"bytes"
 	"compress/flate"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -94,7 +95,13 @@ func (logger BaseLogger) Submit(msg string) {
 			if err != nil {
 				fmt.Errorf("Error applying deflate compression to message: ", err.Error())
 			}
-			w.Write([]byte(msg))
+
+			marshalledMsg, err := json.Marshal(msg)
+			if err != nil {
+				atomic.AddInt64(&logger.submitFailures, 1)
+			}
+
+			w.Write(marshalledMsg)
 			w.Close()
 
 			submitRequest.Write(w)

--- a/src/logger/HttpLogger.go
+++ b/src/logger/HttpLogger.go
@@ -48,7 +48,7 @@ func (logger *HttpLogger) submitIfPassing(details [][]string) {
 
 	details = append(details, []string{"host", logger.host})
 
-	logger.submit(msgStringify(details))
+	logger.Submit(msgStringify(details))
 }
 
 // method for converting message details to string format
@@ -56,7 +56,7 @@ func msgStringify(msg [][]string) string {
 	stringified := ""
 	n := len(msg)
 	for i, val := range msg {
-		stringified += "[" + strings.Join(val, ", ") + "]"
+		stringified += "[\"" + strings.Join(val, "\", \"") + "\"]"
 		if i != n-1 {
 			stringified += ","
 		}


### PR DESCRIPTION
`json.Marshal` is now used in order to create the byte representation of our logging message and `HttpLogger`'s stringify now adds escaped quotations